### PR TITLE
Refacto providers store

### DIFF
--- a/datafusion/src/avro_to_arrow/mod.rs
+++ b/datafusion/src/avro_to_arrow/mod.rs
@@ -28,11 +28,11 @@ use crate::arrow::datatypes::Schema;
 use crate::error::Result;
 #[cfg(feature = "avro")]
 pub use reader::{Reader, ReaderBuilder};
-use std::io::{Read, Seek};
+use std::io::Read;
 
 #[cfg(feature = "avro")]
 /// Read Avro schema given a reader
-pub fn read_avro_schema_from_reader<R: Read + Seek>(reader: &mut R) -> Result<Schema> {
+pub fn read_avro_schema_from_reader<R: Read>(reader: &mut R) -> Result<Schema> {
     let avro_reader = avro_rs::Reader::new(reader)?;
     let schema = avro_reader.writer_schema();
     schema::to_arrow_schema(schema)
@@ -40,7 +40,7 @@ pub fn read_avro_schema_from_reader<R: Read + Seek>(reader: &mut R) -> Result<Sc
 
 #[cfg(not(feature = "avro"))]
 /// Read Avro schema given a reader (requires the avro feature)
-pub fn read_avro_schema_from_reader<R: Read + Seek>(_: &mut R) -> Result<Schema> {
+pub fn read_avro_schema_from_reader<R: Read>(_: &mut R) -> Result<Schema> {
     Err(crate::error::DataFusionError::NotImplemented(
         "cannot read avro schema without the 'avro' feature enabled".to_string(),
     ))

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -382,7 +382,7 @@ mod tests {
 mod tests {
     use super::*;
 
-    use crate::datasource::file_format::string_stream;
+    use crate::datasource::object_store::local::local_sized_file_stream;
     use crate::error::DataFusionError;
 
     #[tokio::test]
@@ -390,7 +390,7 @@ mod tests {
         let testdata = crate::test_util::arrow_test_data();
         let filename = format!("{}/avro/alltypes_plain.avro", testdata);
         let schema_result = AvroFormat::default()
-            .infer_schema(string_stream(vec![filename]))
+            .infer_schema(local_sized_file_stream(vec![filename]))
             .await;
         assert!(matches!(
             schema_result,

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -67,7 +67,7 @@ impl FileFormat for AvroFormat {
                 .object_store_registry
                 .get_by_uri(&fmeta.path)?
                 .file_reader(fmeta)?
-                .reader()?;
+                .sync_reader()?;
             let schema = read_avro_schema_from_reader(&mut reader)?;
             schemas.push(schema);
         }

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -34,7 +34,7 @@ use crate::physical_plan::file_format::AvroExec;
 use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::Statistics;
 
-/// Line-delimited Avro `FileFormat` implementation.
+/// Avro `FileFormat` implementation.
 pub struct AvroFormat {
     /// Object store registry
     pub object_store_registry: Arc<ObjectStoreRegistry>,
@@ -63,10 +63,11 @@ impl FileFormat for AvroFormat {
         let mut schemas = vec![];
         while let Some(fmeta_res) = file_stream.next().await {
             let fmeta = fmeta_res?;
-            let fsize = fmeta.size as usize;
-            let object_store = self.object_store_registry.get_by_uri(&fmeta.path)?;
-            let obj_reader = object_store.file_reader(fmeta)?;
-            let mut reader = obj_reader.chunk_reader(0, fsize)?;
+            let mut reader = self
+                .object_store_registry
+                .get_by_uri(&fmeta.path)?
+                .file_reader(fmeta)?
+                .reader()?;
             let schema = read_avro_schema_from_reader(&mut reader)?;
             schemas.push(schema);
         }

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -91,11 +91,11 @@ impl FileFormat for CsvFormat {
 
         while let Some(fmeta_res) = file_stream.next().await {
             let fmeta = fmeta_res?;
-            let fsize = fmeta.size as usize;
-            let object_store = self.object_store_registry.get_by_uri(&fmeta.path)?;
-
-            let obj_reader = object_store.file_reader(fmeta)?;
-            let mut reader = obj_reader.chunk_reader(0, fsize)?;
+            let mut reader = self
+                .object_store_registry
+                .get_by_uri(&fmeta.path)?
+                .file_reader(fmeta)?
+                .reader()?;
             let (schema, records_read) = arrow::csv::reader::infer_reader_schema(
                 &mut reader,
                 self.delimiter,

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -95,7 +95,7 @@ impl FileFormat for CsvFormat {
                 .object_store_registry
                 .get_by_uri(&fmeta.path)?
                 .file_reader(fmeta)?
-                .reader()?;
+                .sync_reader()?;
             let (schema, records_read) = arrow::csv::reader::infer_reader_schema(
                 &mut reader,
                 self.delimiter,

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -24,11 +24,9 @@ use arrow::{self, datatypes::SchemaRef};
 use async_trait::async_trait;
 use futures::StreamExt;
 
-use super::FileFormat;
-use super::PartitionedFile;
-use crate::datasource::object_store::{ObjectReader, ObjectReaderStream, ObjectStore};
+use super::{FileFormat, PhysicalPlanConfig};
+use crate::datasource::object_store::{ObjectReader, ObjectReaderStream};
 use crate::error::Result;
-use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::CsvExec;
 use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::Statistics;
@@ -108,26 +106,19 @@ impl FileFormat for CsvFormat {
 
     async fn create_physical_plan(
         &self,
-        object_store: Arc<dyn ObjectStore>,
-        schema: SchemaRef,
-        files: Vec<Vec<PartitionedFile>>,
-        statistics: Statistics,
-        projection: &Option<Vec<usize>>,
-        batch_size: usize,
-        _filters: &[Expr],
-        limit: Option<usize>,
+        conf: PhysicalPlanConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let exec = CsvExec::new(
-            object_store,
+            conf.object_store,
             // flattening this for now because CsvExec does not support partitioning yet
-            files.into_iter().flatten().collect(),
-            statistics,
-            schema,
+            conf.files.into_iter().flatten().collect(),
+            conf.statistics,
+            conf.schema,
             self.has_header,
             self.delimiter,
-            projection.clone(),
-            batch_size,
-            limit,
+            conf.projection,
+            conf.batch_size,
+            conf.limit,
         );
         Ok(Arc::new(exec))
     }
@@ -139,9 +130,12 @@ mod tests {
 
     use super::*;
     use crate::{
-        datasource::object_store::local::{
-            local_file_meta, local_object_reader, local_object_reader_stream,
-            LocalFileSystem,
+        datasource::{
+            file_format::{PartitionedFile, PhysicalPlanConfig},
+            object_store::local::{
+                local_file_meta, local_object_reader, local_object_reader_stream,
+                LocalFileSystem,
+            },
         },
         physical_plan::collect,
     };
@@ -255,7 +249,7 @@ mod tests {
             .infer_schema(local_object_reader_stream(vec![filename.clone()]))
             .await
             .expect("Schema inference");
-        let stats = format
+        let statistics = format
             .infer_stats(local_object_reader(filename.clone()))
             .await
             .expect("Stats inference");
@@ -263,16 +257,16 @@ mod tests {
             file_meta: local_file_meta(filename.to_owned()),
         }]];
         let exec = format
-            .create_physical_plan(
-                Arc::new(LocalFileSystem {}),
+            .create_physical_plan(PhysicalPlanConfig {
+                object_store: Arc::new(LocalFileSystem {}),
                 schema,
                 files,
-                stats,
-                projection,
+                statistics,
+                projection: projection.clone(),
                 batch_size,
-                &[],
+                filters: vec![],
                 limit,
-            )
+            })
             .await?;
         Ok(exec)
     }

--- a/datafusion/src/datasource/file_format/json.rs
+++ b/datafusion/src/datasource/file_format/json.rs
@@ -81,7 +81,7 @@ impl FileFormat for JsonFormat {
                 .object_store_registry
                 .get_by_uri(&fmeta.path)?
                 .file_reader(fmeta)?
-                .reader()?;
+                .sync_reader()?;
             let mut reader = BufReader::new(reader);
             let iter = ValueIter::new(&mut reader, None);
             let schema = infer_json_schema_from_iterator(iter.take_while(|_| {

--- a/datafusion/src/datasource/file_format/mod.rs
+++ b/datafusion/src/datasource/file_format/mod.rs
@@ -34,7 +34,7 @@ use crate::physical_plan::{Accumulator, ExecutionPlan, Statistics};
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 
-use super::object_store::{ObjectStoreRegistry, SizedFile, SizedFileStream};
+use super::object_store::{FileMeta, FileMetaStream, ObjectStoreRegistry};
 
 /// This trait abstracts all the file format specific implementations
 /// from the `TableProvider`. This helps code re-utilization accross
@@ -42,10 +42,10 @@ use super::object_store::{ObjectStoreRegistry, SizedFile, SizedFileStream};
 #[async_trait]
 pub trait FileFormat: Send + Sync {
     /// Infer the the common schema of the files described by the path stream
-    async fn infer_schema(&self, paths: SizedFileStream) -> Result<SchemaRef>;
+    async fn infer_schema(&self, paths: FileMetaStream) -> Result<SchemaRef>;
 
     /// Infer the statistics for the file at the given path
-    async fn infer_stats(&self, path: SizedFile) -> Result<Statistics>;
+    async fn infer_stats(&self, path: FileMeta) -> Result<Statistics>;
 
     /// Take a list of files and convert it to the appropriate executor
     /// according to this file format.
@@ -159,7 +159,7 @@ pub async fn get_statistics_with_limit(
 /// TODO move back to crate::datasource::mod.rs once legacy cleaned up
 pub struct PartitionedFile {
     /// Path for the file (e.g. URL, filesystem path, etc)
-    pub file: SizedFile,
+    pub file: FileMeta,
     // Values of partition columns to be appended to each row
     // pub partition_value: Option<Vec<ScalarValue>>,
     // We may include row group range here for a more fine-grained parallel execution

--- a/datafusion/src/datasource/file_format/mod.rs
+++ b/datafusion/src/datasource/file_format/mod.rs
@@ -36,24 +36,15 @@ use futures::{Stream, StreamExt};
 
 use super::object_store::{ObjectStoreRegistry, SizedFile, SizedFileStream};
 
-// /// A stream of String that can be used accross await calls
-// pub type StringStream = Pin<Box<dyn Stream<Item = String> + Send + Sync>>;
-
-// /// Convert a vector into a stream
-// pub fn string_stream(strings: Vec<String>) -> StringStream {
-//     Box::pin(futures::stream::iter(strings))
-// }
-
 /// This trait abstracts all the file format specific implementations
 /// from the `TableProvider`. This helps code re-utilization accross
 /// providers that support the the same file formats.
 #[async_trait]
 pub trait FileFormat: Send + Sync {
-    /// Open the files at the paths provided by iterator and infer the
-    /// common schema
+    /// Infer the the common schema of the files described by the path stream
     async fn infer_schema(&self, paths: SizedFileStream) -> Result<SchemaRef>;
 
-    /// Open the file at the given path and infer its statistics
+    /// Infer the statistics for the file at the given path
     async fn infer_stats(&self, path: SizedFile) -> Result<Statistics>;
 
     /// Take a list of files and convert it to the appropriate executor

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -337,7 +337,7 @@ impl ChunkReader for ChunkObjectReader {
 
     fn get_read(&self, start: u64, length: usize) -> ParquetResult<Self::T> {
         self.0
-            .chunk_reader(start, length)
+            .sync_chunk_reader(start, length)
             .map_err(|e| ParquetError::ArrowError(e.to_string()))
     }
 }

--- a/datafusion/src/datasource/listing.rs
+++ b/datafusion/src/datasource/listing.rs
@@ -242,37 +242,19 @@ mod tests {
 
     #[test]
     fn test_split_files() {
+        let new_partitioned_file = |path: &str| PartitionedFile {
+            file: SizedFile {
+                path: path.to_owned(),
+                size: 10,
+                last_modified: None,
+            },
+        };
         let files = vec![
-            PartitionedFile {
-                file: SizedFile {
-                    path: "a".to_owned(),
-                    size: 10,
-                },
-            },
-            PartitionedFile {
-                file: SizedFile {
-                    path: "b".to_owned(),
-                    size: 10,
-                },
-            },
-            PartitionedFile {
-                file: SizedFile {
-                    path: "c".to_owned(),
-                    size: 10,
-                },
-            },
-            PartitionedFile {
-                file: SizedFile {
-                    path: "d".to_owned(),
-                    size: 10,
-                },
-            },
-            PartitionedFile {
-                file: SizedFile {
-                    path: "e".to_owned(),
-                    size: 10,
-                },
-            },
+            new_partitioned_file("a"),
+            new_partitioned_file("b"),
+            new_partitioned_file("c"),
+            new_partitioned_file("d"),
+            new_partitioned_file("e"),
         ];
 
         let chunks = split_files(files.clone(), 1);
@@ -390,6 +372,7 @@ mod tests {
                 Ok(SizedFile {
                     path: format!("{}file{}", prefix, i),
                     size: 100,
+                    last_modified: None,
                 })
             });
             Ok(Box::pin(futures::stream::iter(files)))

--- a/datafusion/src/datasource/listing.rs
+++ b/datafusion/src/datasource/listing.rs
@@ -128,7 +128,7 @@ impl TableProvider for ListingTable {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // list files (with partitions)
         let file_list = pruned_partition_list(
-            &self.options.format.object_store_registry(),
+            self.options.format.object_store_registry(),
             &self.path,
             filters,
             &self.options.file_extension,

--- a/datafusion/src/datasource/listing.rs
+++ b/datafusion/src/datasource/listing.rs
@@ -235,7 +235,7 @@ fn split_files(
 mod tests {
     use crate::datasource::{
         file_format::{avro::AvroFormat, parquet::ParquetFormat},
-        object_store::{ListEntryStream, ObjectStore, SizedFile, SizedFileStream},
+        object_store::{FileMeta, FileMetaStream, ListEntryStream, ObjectStore},
     };
 
     use super::*;
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn test_split_files() {
         let new_partitioned_file = |path: &str| PartitionedFile {
-            file: SizedFile {
+            file: FileMeta {
                 path: path.to_owned(),
                 size: 10,
                 last_modified: None,
@@ -366,10 +366,10 @@ mod tests {
 
     #[async_trait]
     impl ObjectStore for MockObjectStore {
-        async fn list_file(&self, prefix: &str) -> Result<SizedFileStream> {
+        async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
             let prefix = prefix.to_owned();
             let files = (0..self.files_in_folder).map(move |i| {
-                Ok(SizedFile {
+                Ok(FileMeta {
                     path: format!("{}file{}", prefix, i),
                     size: 100,
                     last_modified: None,
@@ -388,7 +388,7 @@ mod tests {
 
         fn file_reader(
             &self,
-            _file: SizedFile,
+            _file: FileMeta,
         ) -> Result<Arc<dyn crate::datasource::object_store::ObjectReader>> {
             unimplemented!()
         }

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -135,7 +135,7 @@ async fn list_all(prefix: String) -> Result<SizedFileStream> {
     }
 }
 
-/// Create a stream of `SizedFile` applying `local_sized_file` to each path
+/// Create a stream of `SizedFile` applying `local_sized_file` to each path in `files`
 pub fn local_sized_file_stream(files: Vec<String>) -> SizedFileStream {
     Box::pin(futures::stream::iter(files).map(|f| Ok(local_sized_file(f))))
 }

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -22,7 +22,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::{stream, StreamExt};
+use futures::{stream, AsyncRead, StreamExt};
 
 use crate::datasource::object_store::{
     ListEntryStream, ObjectReader, ObjectStore, SizedFile, SizedFileStream,
@@ -65,7 +65,17 @@ impl LocalFileReader {
 
 #[async_trait]
 impl ObjectReader for LocalFileReader {
-    fn chunk_reader(
+    async fn chunk_reader(
+        &self,
+        _start: u64,
+        _length: usize,
+    ) -> Result<Box<dyn AsyncRead>> {
+        todo!(
+            "implement once async file readers are available (arrow-rs#78, arrow-rs#111)"
+        )
+    }
+
+    fn sync_chunk_reader(
         &self,
         start: u64,
         length: usize,

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -70,6 +70,8 @@ impl ObjectReader for LocalFileReader {
         start: u64,
         length: usize,
     ) -> Result<Box<dyn Read + Send + Sync>> {
+        // A new file descriptor is opened for each chunk reader.
+        // This okay because chunks are usually fairly large.
         let mut file = File::open(&self.file.path)?;
         file.seek(SeekFrom::Start(start))?;
         Ok(Box::new(file.take(length as u64)))

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -97,6 +97,7 @@ async fn list_all(prefix: String) -> Result<SizedFileStream> {
         SizedFile {
             path,
             size: metadata.len(),
+            last_modified: metadata.modified().map(chrono::DateTime::from).ok(),
         }
     }
 
@@ -154,9 +155,11 @@ pub fn local_sized_file_stream(files: Vec<String>) -> SizedFileStream {
 
 /// Helper method to fetch the file size at given path and create a `SizedFile`
 pub fn local_sized_file(file: String) -> SizedFile {
+    let metadata = fs::metadata(&file).expect("Local file metadata");
     SizedFile {
-        size: fs::metadata(&file).expect("Local file metadata").len(),
+        size: metadata.len(),
         path: file,
+        last_modified: metadata.modified().map(chrono::DateTime::from).ok(),
     }
 }
 

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -68,11 +68,11 @@ impl ObjectReader for LocalFileReader {
     fn chunk_reader(
         &self,
         start: u64,
-        _length: usize,
+        length: usize,
     ) -> Result<Box<dyn Read + Send + Sync>> {
         let mut file = File::open(&self.file.path)?;
         file.seek(SeekFrom::Start(start))?;
-        Ok(Box::new(file))
+        Ok(Box::new(file.take(length as u64)))
     }
 
     fn length(&self) -> u64 {

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -44,6 +44,11 @@ pub trait ObjectReader {
         length: usize,
     ) -> Result<Box<dyn Read + Send + Sync>>;
 
+    /// Get reader for the entire file
+    fn reader(&self) -> Result<Box<dyn Read + Send + Sync>> {
+        self.chunk_reader(0, self.length() as usize)
+    }
+
     /// Get the size of the file
     fn length(&self) -> u64;
 }

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -32,9 +32,9 @@ use local::LocalFileSystem;
 
 use crate::error::{DataFusionError, Result};
 
-/**
-Object Reader for one file in an object store
-*/
+/// Object Reader for one file in an object store
+/// Note that the dynamic dispatch on the reader might
+/// have some performance impacts.
 #[async_trait]
 pub trait ObjectReader {
     /// Get reader for a part [start, start + length] in the file

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -58,10 +58,11 @@ pub trait ObjectReader {
     fn length(&self) -> u64;
 }
 
-/// Represents a file or a prefix that may require further resolution
+/// Represents a specific file or a prefix (folder) that may
+/// require further resolution
 #[derive(Debug)]
 pub enum ListEntry {
-    /// Complete file path with size
+    /// Specific file with metadata
     FileMeta(FileMeta),
     /// Prefix to be further resolved during partition discovery
     Prefix(String),

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -37,27 +37,27 @@ Object Reader for one file in an object store
 */
 #[async_trait]
 pub trait ObjectReader {
-    /// Get reader for a part [start, start + length] in the file asynchronously
+    /// Get reader for a part [start, start + length] in the file
     fn chunk_reader(
         &self,
         start: u64,
         length: usize,
     ) -> Result<Box<dyn Read + Send + Sync>>;
 
-    /// Get length for the file
+    /// Get the size of the file
     fn length(&self) -> u64;
 }
 
 /// Represents a file or a prefix that may require further resolution
 #[derive(Debug)]
 pub enum ListEntry {
-    /// File metadata
+    /// Complete file path with size
     SizedFile(SizedFile),
     /// Prefix to be further resolved during partition discovery
     Prefix(String),
 }
 
-/// File meta we got from object store
+/// Complete file path with size we got from object store
 #[derive(Debug, Clone)]
 pub struct SizedFile {
     /// Path of the file
@@ -72,11 +72,11 @@ impl std::fmt::Display for SizedFile {
     }
 }
 
-/// Stream of files get listed from object store
+/// Stream of files listed from object store
 pub type SizedFileStream =
     Pin<Box<dyn Stream<Item = Result<SizedFile>> + Send + Sync + 'static>>;
 
-/// Stream of list entries get from object store
+/// Stream of list entries obtained from object store
 pub type ListEntryStream =
     Pin<Box<dyn Stream<Item = Result<ListEntry>> + Send + Sync + 'static>>;
 

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -26,6 +26,7 @@ use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use futures::{AsyncRead, Stream, StreamExt};
 
 use local::LocalFileSystem;
@@ -73,6 +74,11 @@ pub struct SizedFile {
     pub path: String,
     /// File size in total
     pub size: u64,
+    /// The last modification time of the file according to the
+    /// object store metadata. This information might be used by
+    /// catalog systems like Delta Lake for time travel (see
+    /// https://github.com/delta-io/delta/issues/192)
+    pub last_modified: Option<DateTime<Utc>>,
 }
 
 impl std::fmt::Display for SizedFile {

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -216,12 +216,17 @@ impl ObjectStoreRegistry {
     }
 
     /// Get a suitable store for the URI based on it's scheme. For example:
-    /// URI with scheme file or no schema will return the default LocalFS store,
-    /// URI with scheme s3 will return the S3 store if it's registered.
-    pub fn get_by_uri(&self, uri: &str) -> Result<Arc<dyn ObjectStore>> {
-        if let Some((scheme, _)) = uri.split_once(':') {
+    /// - URI with scheme `file://` or no schema will return the default LocalFS store
+    /// - URI with scheme `s3://` will return the S3 store if it's registered
+    /// Returns a tuple with the store and the path of the file in that store
+    /// (URI=scheme://path).
+    pub fn get_by_uri<'a>(
+        &self,
+        uri: &'a str,
+    ) -> Result<(Arc<dyn ObjectStore>, &'a str)> {
+        if let Some((scheme, path)) = uri.split_once("://") {
             let stores = self.object_stores.read().unwrap();
-            stores
+            let store = stores
                 .get(&*scheme.to_lowercase())
                 .map(Clone::clone)
                 .ok_or_else(|| {
@@ -229,9 +234,10 @@ impl ObjectStoreRegistry {
                         "No suitable object store found for {}",
                         scheme
                     ))
-                })
+                })?;
+            Ok((store, path))
         } else {
-            Ok(Arc::new(LocalFileSystem))
+            Ok((Arc::new(LocalFileSystem), uri))
         }
     }
 }

--- a/datafusion/src/physical_plan/file_format/avro.rs
+++ b/datafusion/src/physical_plan/file_format/avro.rs
@@ -129,7 +129,7 @@ impl ExecutionPlan for AvroExec {
             .object_store_registry
             .get_by_uri(&self.files[partition].file.path)?
             .file_reader(self.files[partition].file.clone())?
-            .reader()?;
+            .sync_reader()?;
 
         let proj = self.projection.as_ref().map(|p| {
             p.iter()

--- a/datafusion/src/physical_plan/file_format/avro.rs
+++ b/datafusion/src/physical_plan/file_format/avro.rs
@@ -244,7 +244,7 @@ impl<R: Read + Unpin> RecordBatchStream for AvroStream<'_, R> {
 mod tests {
 
     use crate::datasource::object_store::local::{
-        local_sized_file, local_sized_file_stream,
+        local_file_meta, local_file_meta_stream,
     };
 
     use super::*;
@@ -260,11 +260,11 @@ mod tests {
         let avro_exec = AvroExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![PartitionedFile {
-                file: local_sized_file(filename.clone()),
+                file: local_file_meta(filename.clone()),
             }],
             Statistics::default(),
             AvroFormat::default()
-                .infer_schema(local_sized_file_stream(vec![filename]))
+                .infer_schema(local_file_meta_stream(vec![filename]))
                 .await?,
             Some(vec![0, 1, 2]),
             1024,

--- a/datafusion/src/physical_plan/file_format/avro.rs
+++ b/datafusion/src/physical_plan/file_format/avro.rs
@@ -129,7 +129,7 @@ impl ExecutionPlan for AvroExec {
             .object_store_registry
             .get_by_uri(&self.files[partition].file.path)?
             .file_reader(self.files[partition].file.clone())?
-            .chunk_reader(0, self.files[partition].file.size as usize)?;
+            .reader()?;
 
         let proj = self.projection.as_ref().map(|p| {
             p.iter()

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -196,7 +196,7 @@ impl CsvStream<Box<dyn Read + Send + Sync>> {
         let file = object_store_registry
             .get_by_uri(&file.path)?
             .file_reader(file.clone())?
-            .reader()?;
+            .sync_reader()?;
         Self::try_new_from_reader(
             file, schema, has_header, delimiter, projection, batch_size, limit,
         )

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -236,7 +236,7 @@ impl<R: Read + Unpin> RecordBatchStream for CsvStream<R> {
 mod tests {
     use super::*;
     use crate::{
-        datasource::object_store::local::local_sized_file, test::aggr_test_schema,
+        datasource::object_store::local::local_file_meta, test::aggr_test_schema,
     };
     use futures::StreamExt;
 
@@ -249,7 +249,7 @@ mod tests {
         let csv = CsvExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![PartitionedFile {
-                file: local_sized_file(path),
+                file: local_file_meta(path),
             }],
             Statistics::default(),
             schema,
@@ -282,7 +282,7 @@ mod tests {
         let csv = CsvExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![PartitionedFile {
-                file: local_sized_file(path),
+                file: local_file_meta(path),
             }],
             Statistics::default(),
             schema,

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -196,7 +196,7 @@ impl CsvStream<Box<dyn Read + Send + Sync>> {
         let file = object_store_registry
             .get_by_uri(&file.path)?
             .file_reader(file.clone())?
-            .chunk_reader(0, file.size as usize)?;
+            .reader()?;
         Self::try_new_from_reader(
             file, schema, has_header, delimiter, projection, batch_size, limit,
         )

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -182,6 +182,7 @@ struct CsvStream<R: Read> {
 }
 impl CsvStream<Box<dyn Read + Send + Sync>> {
     /// Create an iterator for a CSV file
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         object_store_registry: &ObjectStoreRegistry,
         file: &SizedFile,

--- a/datafusion/src/physical_plan/file_format/json.rs
+++ b/datafusion/src/physical_plan/file_format/json.rs
@@ -129,7 +129,7 @@ impl ExecutionPlan for NdJsonExec {
             .object_store_registry
             .get_by_uri(&self.files[partition].file.path)?
             .file_reader(self.files[partition].file.clone())?
-            .chunk_reader(0, self.files[partition].file.size as usize)?;
+            .reader()?;
 
         let json_reader = json::Reader::new(file, self.schema(), self.batch_size, proj);
 

--- a/datafusion/src/physical_plan/file_format/json.rs
+++ b/datafusion/src/physical_plan/file_format/json.rs
@@ -129,7 +129,7 @@ impl ExecutionPlan for NdJsonExec {
             .object_store_registry
             .get_by_uri(&self.files[partition].file.path)?
             .file_reader(self.files[partition].file.clone())?
-            .reader()?;
+            .sync_reader()?;
 
         let json_reader = json::Reader::new(file, self.schema(), self.batch_size, proj);
 

--- a/datafusion/src/physical_plan/file_format/json.rs
+++ b/datafusion/src/physical_plan/file_format/json.rs
@@ -229,7 +229,7 @@ mod tests {
 
     use crate::datasource::{
         file_format::{json::JsonFormat, FileFormat},
-        object_store::local::{local_sized_file, local_sized_file_stream},
+        object_store::local::{local_file_meta, local_file_meta_stream},
     };
 
     use super::*;
@@ -238,7 +238,7 @@ mod tests {
 
     async fn infer_schema(path: String) -> Result<SchemaRef> {
         JsonFormat::default()
-            .infer_schema(local_sized_file_stream(vec![path]))
+            .infer_schema(local_file_meta_stream(vec![path]))
             .await
     }
 
@@ -249,7 +249,7 @@ mod tests {
         let exec = NdJsonExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![PartitionedFile {
-                file: local_sized_file(path.clone()),
+                file: local_file_meta(path.clone()),
             }],
             Default::default(),
             infer_schema(path).await?,
@@ -304,7 +304,7 @@ mod tests {
         let exec = NdJsonExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![PartitionedFile {
-                file: local_sized_file(path.clone()),
+                file: local_file_meta(path.clone()),
             }],
             Default::default(),
             infer_schema(path).await?,

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -543,7 +543,7 @@ fn read_partition(
 mod tests {
     use crate::datasource::{
         file_format::{parquet::ParquetFormat, FileFormat},
-        object_store::local::{local_sized_file, local_sized_file_stream},
+        object_store::local::{local_file_meta, local_file_meta_stream},
     };
 
     use super::*;
@@ -562,11 +562,11 @@ mod tests {
         let parquet_exec = ParquetExec::new(
             Arc::new(ObjectStoreRegistry::new()),
             vec![vec![PartitionedFile {
-                file: local_sized_file(filename.clone()),
+                file: local_file_meta(filename.clone()),
             }]],
             Statistics::default(),
             ParquetFormat::default()
-                .infer_schema(local_sized_file_stream(vec![filename]))
+                .infer_schema(local_file_meta_stream(vec![filename]))
                 .await?,
             Some(vec![0, 1, 2]),
             None,

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -110,7 +110,8 @@ struct ParquetFileMetrics {
 }
 
 impl ParquetExec {
-    /// Create a new Parquet reader execution plan provided file list and schema
+    /// Create a new Parquet reader execution plan provided file list and schema.
+    /// Even if `limit` is set, ParquetExec rounds up the number of records to the next `batch_size`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         object_store_registry: Arc<ObjectStoreRegistry>,

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -111,6 +111,7 @@ struct ParquetFileMetrics {
 
 impl ParquetExec {
     /// Create a new Parquet reader execution plan provided file list and schema
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         object_store_registry: Arc<ObjectStoreRegistry>,
         files: Vec<Vec<PartitionedFile>>,


### PR DESCRIPTION
 # Rationale for this change
Add `ObjectStore` support to https://github.com/apache/arrow-datafusion/pull/1010

# What changes are included in this PR?
- Include the `ObjectStore` abstractions to the new implementations of `FileFormat`, `TableProvider` and `ExecutionPlan`
- changes the object store API:
  - adding `ObjectReader.sync_chunk_reader` to be compatible with the Parquet `ChunkReader` trait
  - `ObjectReader.sync_chunk_reader` returns `Read` instead of `AsyncRead` to accomodate input types of CSV, json, avro and Parquet reader APIs
  - keeping  `ObjectReader.chunk_reader` in prevision to the new async reader API
  - `ObjectStore.file_reader()` now takes `SizedFile` instead of `FileMeta` because only path and size are required there
- removing useless `Seek` trait bound in `avro_to_arrow`
- Added some tests to better cover the limit behaviour at the `file_format` level

# Are there any user-facing changes?
`ObjectStore` is user-facing but probably not used by any users yet.


